### PR TITLE
Set ALLOW_EMPTY_PASSWORD in redis for kubernetes. Kubernetes YAML refactor

### DIFF
--- a/kubernetes.yml
+++ b/kubernetes.yml
@@ -1,5 +1,77 @@
 apiVersion: v1
 items:
+# Volumes
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    creationTimestamp: null
+    labels:
+      io.kompose.service: dreamfactory-dreamfactory-data
+    name: dreamfactory-dreamfactory-data
+  spec:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 100Mi
+  status: {}
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    creationTimestamp: null
+    labels:
+      io.kompose.service: dreamfactory-apache-data
+    name: dreamfactory-apache-data
+  spec:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 100Mi
+  status: {}
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    creationTimestamp: null
+    labels:
+      io.kompose.service: dreamfactory-php-data
+    name: dreamfactory-php-data
+  spec:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 100Mi
+  status: {}
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    creationTimestamp: null
+    labels:
+      io.kompose.service: dreamfactory-redis-data
+    name: dreamfactory-redis-data
+  spec:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 100Mi
+  status: {}
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    creationTimestamp: null
+    labels:
+      io.kompose.service: dreamfactory-mariadb-data
+    name: dreamfactory-mariadb-data
+  spec:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 100Mi
+  status: {}
+# Services
 - apiVersion: v1
   kind: Service
   metadata:
@@ -73,6 +145,89 @@ items:
       io.kompose.service: redis
   status:
     loadBalancer: {}
+# Deployments
+- apiVersion: extensions/v1beta1
+  kind: Deployment
+  metadata:
+    creationTimestamp: null
+    name: mariadb
+  spec:
+    replicas: 1
+    strategy:
+      type: Recreate
+    template:
+      metadata:
+        creationTimestamp: null
+        labels:
+          io.kompose.service: mariadb
+      spec:
+        containers:
+        - env:
+          - name: ALLOW_EMPTY_PASSWORD
+            value: "yes"
+          image: bitnami/mariadb:latest
+          name: mariadb
+          resources: {}
+          volumeMounts:
+          - mountPath: /bitnami/mariadb
+            name: dreamfactory-mariadb-data
+        restartPolicy: Always
+        volumes:
+        - name: dreamfactory-mariadb-data
+          persistentVolumeClaim:
+            claimName: dreamfactory-mariadb-data
+  status: {}
+- apiVersion: extensions/v1beta1
+  kind: Deployment
+  metadata:
+    creationTimestamp: null
+    name: mongodb
+  spec:
+    replicas: 1
+    strategy: {}
+    template:
+      metadata:
+        creationTimestamp: null
+        labels:
+          io.kompose.service: mongodb
+      spec:
+        containers:
+        - image: bitnami/mongodb:latest
+          name: mongodb
+          resources: {}
+        restartPolicy: Always
+  status: {}
+- apiVersion: extensions/v1beta1
+  kind: Deployment
+  metadata:
+    creationTimestamp: null
+    name: redis
+  spec:
+    replicas: 1
+    strategy:
+      type: Recreate
+    template:
+      metadata:
+        creationTimestamp: null
+        labels:
+          io.kompose.service: redis
+      spec:
+        containers:
+        - env:
+          - name: ALLOW_EMPTY_PASSWORD
+            value: "yes"
+          image: bitnami/redis:latest
+          name: redis
+          resources: {}
+          volumeMounts:
+          - mountPath: /bitnami/redis
+            name: dreamfactory-redis-data
+        restartPolicy: Always
+        volumes:
+        - name: dreamfactory-redis-data
+          persistentVolumeClaim:
+            claimName: dreamfactory-redis-data
+  status: {}
 - apiVersion: extensions/v1beta1
   kind: Deployment
   metadata:
@@ -116,155 +271,5 @@ items:
           persistentVolumeClaim:
             claimName: dreamfactory-php-data
   status: {}
-- apiVersion: v1
-  kind: PersistentVolumeClaim
-  metadata:
-    creationTimestamp: null
-    labels:
-      io.kompose.service: dreamfactory-dreamfactory-data
-    name: dreamfactory-dreamfactory-data
-  spec:
-    accessModes:
-    - ReadWriteOnce
-    resources:
-      requests:
-        storage: 100Mi
-  status: {}
-- apiVersion: v1
-  kind: PersistentVolumeClaim
-  metadata:
-    creationTimestamp: null
-    labels:
-      io.kompose.service: dreamfactory-apache-data
-    name: dreamfactory-apache-data
-  spec:
-    accessModes:
-    - ReadWriteOnce
-    resources:
-      requests:
-        storage: 100Mi
-  status: {}
-- apiVersion: v1
-  kind: PersistentVolumeClaim
-  metadata:
-    creationTimestamp: null
-    labels:
-      io.kompose.service: dreamfactory-php-data
-    name: dreamfactory-php-data
-  spec:
-    accessModes:
-    - ReadWriteOnce
-    resources:
-      requests:
-        storage: 100Mi
-  status: {}
-- apiVersion: extensions/v1beta1
-  kind: Deployment
-  metadata:
-    creationTimestamp: null
-    name: mariadb
-  spec:
-    replicas: 1
-    strategy:
-      type: Recreate
-    template:
-      metadata:
-        creationTimestamp: null
-        labels:
-          io.kompose.service: mariadb
-      spec:
-        containers:
-        - env:
-          - name: ALLOW_EMPTY_PASSWORD
-            value: "yes"
-          image: bitnami/mariadb:latest
-          name: mariadb
-          resources: {}
-          volumeMounts:
-          - mountPath: /bitnami/mariadb
-            name: dreamfactory-mariadb-data
-        restartPolicy: Always
-        volumes:
-        - name: dreamfactory-mariadb-data
-          persistentVolumeClaim:
-            claimName: dreamfactory-mariadb-data
-  status: {}
-- apiVersion: v1
-  kind: PersistentVolumeClaim
-  metadata:
-    creationTimestamp: null
-    labels:
-      io.kompose.service: dreamfactory-mariadb-data
-    name: dreamfactory-mariadb-data
-  spec:
-    accessModes:
-    - ReadWriteOnce
-    resources:
-      requests:
-        storage: 100Mi
-  status: {}
-- apiVersion: extensions/v1beta1
-  kind: Deployment
-  metadata:
-    creationTimestamp: null
-    name: mongodb
-  spec:
-    replicas: 1
-    strategy: {}
-    template:
-      metadata:
-        creationTimestamp: null
-        labels:
-          io.kompose.service: mongodb
-      spec:
-        containers:
-        - image: bitnami/mongodb:latest
-          name: mongodb
-          resources: {}
-        restartPolicy: Always
-  status: {}
-- apiVersion: extensions/v1beta1
-  kind: Deployment
-  metadata:
-    creationTimestamp: null
-    name: redis
-  spec:
-    replicas: 1
-    strategy:
-      type: Recreate
-    template:
-      metadata:
-        creationTimestamp: null
-        labels:
-          io.kompose.service: redis
-      spec:
-        containers:
-        - image: bitnami/redis:latest
-          name: redis
-          resources: {}
-          volumeMounts:
-          - mountPath: /bitnami/redis
-            name: dreamfactory-redis-data
-        restartPolicy: Always
-        volumes:
-        - name: dreamfactory-redis-data
-          persistentVolumeClaim:
-            claimName: dreamfactory-redis-data
-  status: {}
-- apiVersion: v1
-  kind: PersistentVolumeClaim
-  metadata:
-    creationTimestamp: null
-    labels:
-      io.kompose.service: dreamfactory-redis-data
-    name: dreamfactory-redis-data
-  spec:
-    accessModes:
-    - ReadWriteOnce
-    resources:
-      requests:
-        storage: 100Mi
-  status: {}
 kind: List
 metadata: {}
-


### PR DESCRIPTION
**Description of the change**

* Add ALLOW_EMPTY_PASSWORD  for redis 
* Refactor (re-order) of Kubernetes YAML file.

**Benefits**

* Dreamfactory over kubernetes now start correctly (redis does not fail).
* YAML file is more readable and easier to maintain (no other changes on code, just reorder and added comments).

**Possible drawbacks**
None.

**Applicable issues**
None of my knowledge.

**Additional information**
N/A.